### PR TITLE
Removed tower-cookies. Upgraded to Axum 0.6.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ repository = "https://github.com/davidpdrsn/axum-flash"
 
 [dependencies]
 async-trait = "0.1"
-axum-core = { version = "0.2" }
+axum-core = "0.3.0-rc.1"
+axum-extra = {version = "0.4.0-rc.1", features = ["cookie", "cookie-signed"]}
 base64 = "0.13"
 cookie = { version = "0.16", features = ["signed", "percent-encode"] }
 http = "0.2"
 percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tower-cookies = "0.7"
 tower-layer = "0.3"
 tower-service = "0.3"
 
 [dev-dependencies]
-axum = { version = "0.5", default_features = true }
+axum = { version = "0.6.0-rc.1", default_features = true }
 hyper = "0.14"
-tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
 tower = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ axum-extra = {version = "0.4.0-rc.1", features = ["cookie", "cookie-signed"]}
 base64 = "0.13"
 cookie = { version = "0.16", features = ["signed", "percent-encode"] }
 http = "0.2"
-percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tower-layer = "0.3"

--- a/src/incoming_flash.rs
+++ b/src/incoming_flash.rs
@@ -3,8 +3,8 @@
 use crate::{private::SigningKey, FlashMessage, Level, COOKIE_NAME};
 use async_trait::async_trait;
 use axum_core::extract::FromRequestParts;
-use axum_extra::extract::{cookie::Cookie, SignedCookieJar};
-use http::{header::SET_COOKIE, request::Parts, StatusCode};
+use axum_extra::extract::SignedCookieJar;
+use http::{request::Parts, StatusCode};
 
 /// Extractor for incoming flash messages.
 ///
@@ -82,16 +82,6 @@ where
             .and_then(|cookie| serde_json::from_str::<Vec<FlashMessage>>(cookie.value()).ok())
             .unwrap_or_default();
 
-        let cookies = cookies.remove(Cookie::named(COOKIE_NAME));
-
-        //remove the old cookies to replace it with the new that doesnt include the IncomingFlashes.
-        parts.headers.remove(SET_COOKIE);
-
-        for cookie in cookies.iter() {
-            if let Ok(header_value) = cookie.encoded().to_string().parse() {
-                parts.headers.append(SET_COOKIE, header_value);
-            }
-        }
         Ok(Self { flashes })
     }
 }

--- a/src/incoming_flash.rs
+++ b/src/incoming_flash.rs
@@ -13,7 +13,7 @@ use std::convert::Infallible;
 /// Extractor for incoming flash messages.
 ///
 /// See [root module docs](crate) for an example.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IncomingFlashes {
     flashes: Vec<FlashMessage>,
     use_secure_cookies: bool,

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,7 +7,6 @@ use crate::{
     SigningKey,
 };
 use cookie::Key;
-use tower_cookies::CookieManagerLayer;
 use tower_layer::{Layer, Stack};
 
 /// [`Layer`] that applies the necessary middleware for `axum_flash` to work.
@@ -29,15 +28,6 @@ pub struct LayerBuilder<L> {
 }
 
 impl<L> LayerBuilder<L> {
-    /// Also add a [`CookieManagerLayer`] to the middleware stack.
-    ///
-    /// A [`CookieManagerLayer`] is required for `axum_flash` to work. If you're
-    /// manually adding a [`CookieManagerLayer`] elsewhere in your middleware
-    /// stack you don't have to call this method, otherwise you do.
-    pub fn with_cookie_manager(self) -> LayerBuilder<Stack<CookieManagerLayer, L>> {
-        self.push(CookieManagerLayer::new())
-    }
-
     /// Mark the cookie as secure so the cookie will only be sent on `https`.
     ///
     /// Defaults to marking cookies as secure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ mod private;
 /// Extractor for setting outgoing flash messages.
 ///
 /// The flashes will be stored in a signed cookie.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Flash {
     flashes: Vec<FlashMessage>,
     use_secure_cookies: bool,
@@ -210,7 +210,7 @@ pub(crate) fn create_cookie<'a>(value: String, use_secure_cookies: bool) -> Cook
         .finish()
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct FlashMessage {
     #[serde(rename = "l")]
     level: Level,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ use std::{
     time::Duration,
 };
 
+pub use axum_extra::extract::cookie::Key;
 pub mod incoming_flash;
 pub mod layer;
 
@@ -296,7 +297,6 @@ mod tests {
 
     #[tokio::test]
     async fn basic() {
-        use axum_extra::extract::cookie::Key;
         let key = Key::generate();
 
         let app = Router::new()


### PR DESCRIPTION
So the only issue I see is If you dont remember to insert flash.into_response()  then the cookie will never get updated which causes the page to continue getting out going flashes as they don't get replaced or removed.  Removing them in the Out Going doesn't seem to affect this either.

So what do you think?