### PR TITLE
Bump MSRV to 1.65.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ['1.60']
+        rust: ['1.65']
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Unreleased
 
-- None.
+- `axum-flash`'s MSRV is now 1.65.
 
 # 0.6.0 (25. November, 2022)
 


### PR DESCRIPTION
The CI build is currently [failing](https://github.com/davidpdrsn/axum-flash/actions/runs/5055659325/jobs/9072200717) as one dependency requires rustc >=1.65.
